### PR TITLE
Moved OS envs for loop inside when checking for present config file

### DIFF
--- a/mirrortest/session.py
+++ b/mirrortest/session.py
@@ -15,5 +15,6 @@ if (config := pathlib.Path('~/.config/mirrortester/config.json').expanduser()).e
 	[setattr(configuration, key, val) for key, val in json_config.items()]  # type: ignore
 
 	# Update configuration from environment variables (if any)
-	for key, val in os.environ.items():
-		[setattr(configuration, key, val) for key, val in json_config.items()]  # type: ignore
+
+# Update configuration from environment variables (if any)
+[setattr(configuration, key, val) for key, val in os.environ.items()]  # type: ignore

--- a/mirrortest/session.py
+++ b/mirrortest/session.py
@@ -14,6 +14,6 @@ if (config := pathlib.Path('~/.config/mirrortester/config.json').expanduser()).e
 
 	[setattr(configuration, key, val) for key, val in json_config.items()]  # type: ignore
 
-# Update configuration from environment variables (if any)
-for key, val in os.environ.items():
-	[setattr(configuration, key, val) for key, val in json_config.items()]  # type: ignore
+	# Update configuration from environment variables (if any)
+	for key, val in os.environ.items():
+		[setattr(configuration, key, val) for key, val in json_config.items()]  # type: ignore


### PR DESCRIPTION
If i did not have the file created (not sure if i typed the command wrong or not, the project would not run as the for loop would look for an undefined json_config variable. Im not sure contextually if adding the keys from the OS environmental variables in addition to whatever it finds in the file itself, what happens if there are duplicates? I was testing this with the example command from the readme file. 