### PR TITLE
Missing mailto() call in CLI

### DIFF
--- a/mirrortest/mailhandle.py
+++ b/mirrortest/mailhandle.py
@@ -229,6 +229,7 @@ else:
 	if os.environ.get("DISPLAY"):
 		register_X_controllers()
 	_open = get()
+	print(_open)
 
 
 def open(filename):

--- a/mirrortest/models.py
+++ b/mirrortest/models.py
@@ -147,7 +147,7 @@ class MirrorTester(Mirror):
 					Mirror {self.url} is out of date for {last_update_delta}.
 					Please correct this and notify us.
 
-					The mirror has been marked as inactive for nhttpsow.
+					The mirror has been marked as inactive for now.
 
 					//Arch Linux mirror admins""".replace('\t', '')
 				)
@@ -167,7 +167,7 @@ class MirrorTester(Mirror):
 					Mirror {self.url} is out of date for {last_update_delta}.
 					Please correct this and notify us.
 
-					The mirror has been marked as inactive for nhttpsow.
+					The mirror has been marked as inactive for now.
 
 					//Arch Linux mirror admins""".replace('\t', '')
 				)

--- a/mirrortest/tooling/cli.py
+++ b/mirrortest/tooling/cli.py
@@ -9,6 +9,7 @@ from ..models import (
 	Tier0
 )
 
+from ..mailhandle import mailto
 from ..session import configuration
 
 # Parse script arguments and use defaults from configuration where needed
@@ -64,6 +65,22 @@ def run() -> None:
 			Best regards,
 			//Arch Linux mirror team
 		""".replace('\t', ''))
+		if configuration.email:
+			mailto(
+				"",
+				"",
+				"mirrors@archlinux.org",
+				None,
+				f"Arch Linux mirror {args.mirror} is out of date",
+				f"""Hi!
+
+				Your mirror {args.mirror} returns {error.code}.
+				Please correct this and notify us.
+
+				The mirror has been marked as inactive for now.
+
+				//Arch Linux mirror admins""".replace('\t', '')
+			)
 
 	# Upon exiting, store the given configuration used
 	config = pathlib.Path('~/.config/mirrortester/config.json').expanduser()


### PR DESCRIPTION
The missing `mailto` call in `cli.py` made it so `--mail` had no effect when HTML status codes were returned, only out of sync and out of date mirrors would trigger a mail.