### PR TITLE
Added a --mirror '*' option to test all mirrors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /dist
 /build
 /*.tar.gz*
+/*.log

--- a/mirrortest/mailhandle.py
+++ b/mirrortest/mailhandle.py
@@ -229,7 +229,6 @@ else:
 	if os.environ.get("DISPLAY"):
 		register_X_controllers()
 	_open = get()
-	print(_open)
 
 
 def open(filename):

--- a/mirrortest/models.py
+++ b/mirrortest/models.py
@@ -85,8 +85,8 @@ class Tier0(Mirror):
 		return Tier0.request(self.url, f'/{repo}/os/{self.arch}/{repo}.db.tar.gz')
 
 	def refresh(self):
-		self.last_update = datetime.datetime.fromtimestamp(int(Tier0.request(str(values['url']), '/lastupdate').strip()))
-		self.last_sync = datetime.datetime.fromtimestamp(int(Tier0.request(str(values['url']), '/lastsync').strip()))
+		self.last_update = datetime.datetime.fromtimestamp(int(Tier0.request(str(self.url), '/lastupdate').strip()))
+		self.last_sync = datetime.datetime.fromtimestamp(int(Tier0.request(str(self.url), '/lastsync').strip()))
 
 
 class MirrorTester(Mirror):

--- a/mirrortest/models.py
+++ b/mirrortest/models.py
@@ -100,8 +100,10 @@ class MirrorTester(Mirror):
 		So we will update the dictionary of values before being set
 		as class properties (pydantic quirk).
 		"""
-		values['last_sync'] = datetime.datetime.fromtimestamp(int(MirrorTester.request(str(values['url']), '/lastsync').strip()))
-		values['last_update'] = datetime.datetime.fromtimestamp(int(MirrorTester.request(str(values['url']), '/lastupdate').strip()))
+		if last_sync_request := MirrorTester.request(str(values['url']), '/lastsync').strip():
+			values['last_sync'] = datetime.datetime.fromtimestamp(int(last_sync_request))
+		if last_update_request := MirrorTester.request(str(values['url']), '/lastupdate').strip():
+			values['last_update'] = datetime.datetime.fromtimestamp(int(last_update_request))
 
 		return values
 

--- a/mirrortest/tooling/cli.py
+++ b/mirrortest/tooling/cli.py
@@ -115,8 +115,13 @@ def run() -> None:
 					try:
 						mirror = MirrorTester(tier=2, url=url, tier_0=tier_0)
 						good_exit = mirror.valid
-						time_delta_str = tier_0.last_update - mirror.last_update  # type: ignore
-						time_delta_int = time_delta_str.total_seconds()
+
+						if last_update := mirror.last_update:
+							time_delta_str = tier_0.last_update - mirror.last_update  # type: ignore
+							time_delta_int = time_delta_str.total_seconds()
+						else:
+							time_delta_str = 'Could not find /lastupdate on mirror'
+							time_delta_int = -4
 					except urllib.error.HTTPError as error:
 						good_exit = False
 						time_delta_str = str(error)

--- a/mirrortest/tooling/cli.py
+++ b/mirrortest/tooling/cli.py
@@ -116,8 +116,8 @@ def run() -> None:
 						mirror = MirrorTester(tier=2, url=url, tier_0=tier_0)
 						good_exit = mirror.valid
 
-						if last_update := mirror.last_update:
-							time_delta_str = tier_0.last_update - mirror.last_update  # type: ignore
+						if last_update := mirror.last_update:  # type: ignore
+							time_delta_str = tier_0.last_update - last_update  # type: ignore
 							time_delta_int = time_delta_str.total_seconds()
 						else:
 							time_delta_str = 'Could not find /lastupdate on mirror'

--- a/mirrortest/tooling/cli.py
+++ b/mirrortest/tooling/cli.py
@@ -2,6 +2,7 @@ import dataclasses
 import argparse
 import pathlib
 import json
+import time
 import urllib.error
 
 from ..models import (
@@ -51,36 +52,87 @@ args, unknown = main_options.parse_known_args()
 configuration.email = args.mail
 
 
+def check_mirror(url, tier, tier_0):
+	
+
+	return good_exit
+
 def run() -> None:
-	try:
-		good_exit = MirrorTester(tier=args.tier, url=args.mirror, tier_0=Tier0(url=args.tier0)).valid
-	except urllib.error.HTTPError as error:
-		good_exit = False
-		print(f"""
-			Hi!
+	tier_0 = Tier0(url=args.tier0)
 
-			Your mirror {args.mirror} returns {error.code} and has therefor been marked as inactive.
-			Please correct this and get back to us if you wish to re-activate the mirror.
+	if args.mirror != '*':
+		try:
+			good_exit = MirrorTester(tier=args.tier, url=args.mirror, tier_0=tier_0).valid
+		except urllib.error.HTTPError as error:
+			good_exit = False
+		except urllib.error.URLError as error:
+			good_exit = False
 
-			Best regards,
-			//Arch Linux mirror team
-		""".replace('\t', ''))
-		if configuration.email:
-			mailto(
-				"",
-				"",
-				"mirrors@archlinux.org",
-				None,
-				f"Arch Linux mirror {args.mirror} is out of date",
-				f"""Hi!
+		if not (good_exit := check_mirror(args.mirror, tier=args.tier, tier_0=tier_0)):
+			print(f"""
+				Hi!
 
-				Your mirror {args.mirror} returns {error.code}.
-				Please correct this and notify us.
+				Your mirror {args.mirror} returns {error.code} and has therefor been marked as inactive.
+				Please correct this and get back to us if you wish to re-activate the mirror.
 
-				The mirror has been marked as inactive for now.
+				Best regards,
+				//Arch Linux mirror team
+			""".replace('\t', ''))
+			if configuration.email:
+				mailto(
+					"",
+					"",
+					"mirrors@archlinux.org",
+					None,
+					f"Arch Linux mirror {args.mirror} is out of date",
+					f"""Hi!
 
-				//Arch Linux mirror admins""".replace('\t', '')
-			)
+					Your mirror {args.mirror} returns {error.code}.
+					Please correct this and notify us.
+
+					The mirror has been marked as inactive for now.
+
+					//Arch Linux mirror admins""".replace('\t', '')
+				)
+	else:
+		# Retrieve complete mirror list
+		response = urllib.request.urlopen("https://archlinux.org/mirrorlist/all/")
+		data = response.read()
+
+		#bad_mirrors = {}
+		with open(f'output_{time.time()}.log', 'w') as log:
+			for server in data.split(b'\n'):
+
+				if b'#Server = ' not in server:
+					continue
+				elif len(server.strip()) == 0:
+					continue
+
+				if server.startswith(b'#Server'):
+					_, url = server.split(b'=', 1)
+					url, _ = url.split(b'/$repo', 1)
+					url = url.strip().decode()
+
+
+					try:
+						mirror = MirrorTester(tier=2, url=url, tier_0=tier_0)
+						good_exit = mirror.valid
+						time_delta_str = tier_0.last_update - mirror.last_update
+						time_delta_int = time_delta_str.total_seconds()
+					except urllib.error.HTTPError as error:
+						good_exit = False
+						time_delta_str = str(error)
+						time_delta_int = -1
+					except urllib.error.URLError as error:
+						good_exit = False
+						time_delta_str = str(error)
+						time_delta_int = -2
+
+					if not good_exit:
+						#bad_mirrors[url] = {'obj' : mirror, 'delta' : tier_0.last_update - mirror.last_update}
+						log.write(f"{url},{time_delta_int},\"{time_delta_str}\"\n")
+						log.flush()
+
 
 	# Upon exiting, store the given configuration used
 	config = pathlib.Path('~/.config/mirrortester/config.json').expanduser()


### PR DESCRIPTION
This option allows us to go through all the active mirrors and report back status.
The end result will be a `./output_<time>.log` in CSV format and look something like this:

```csv
https://arch-mirror.cloud.louifox.house,-2,"<urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Hostname mismatch, certificate is not valid for 'arch-mirror.cloud.louifox.house'. (_ssl.c:997)>"
https://arch.nimukaito.net,-2,"<urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: certificate has expired (_ssl.c:997)>"
http://mirror.oldsql.cc/archlinux,-2,"<urlopen error [Errno 101] Network is unreachable>"
https://appuals.com/archlinux,91813.0,"1 day, 1:30:13"
https://mirror.fsrv.services/archlinux,-1,"HTTP Error 404: Not Found"
http://www.gutscheindrache.com/mirror/archlinux,-1,"HTTP Error 500: Internal Server Error"
```

Where `"1 day, 1:30:13"` dictates that the mirror is `/lastupdate` older than Tier0 with 1 day, 1h and 30min. Only errors are logged.